### PR TITLE
Add fontWeight to dom.js

### DIFF
--- a/dom.js
+++ b/dom.js
@@ -463,6 +463,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	                y: _this3.calculateYPosition(layers, layerData),
 	                fontFamily: layerData.fontFamily,
 	                fontSize: layerData.fontSize,
+	                fontWeight: layerData.fontWeight,
 	                lineHeight: layerData.lineHeight,
 	                textAnchor: layerData.textAnchor,
 	                fill: layerData.fill,


### PR DESCRIPTION
FontWeight didn't seem to work after your most recent commit. After playing around, I found that adding this line to dom.js made it start working.