### PR TITLE
[improve: code coverage] ColorControl.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "url": "https://github.com/times/cardkit.git"
   },
   "scripts": {
-    "test": "./node_modules/.bin/istanbul cover --dir test/coverage ./node_modules/.bin/_mocha -- --compilers js:babel-core/register --require ignore-styles",
+    "test": "./node_modules/.bin/istanbul cover --dir test/coverage ./node_modules/.bin/_mocha test/**/*.spec.js -- --compilers js:babel-core/register --require ignore-styles",
     "jsdoc": "./node_modules/.bin/jsdoc -c ./jsdoc.config.json -d ./docs/code -t ./node_modules/minami --verbose -R ./README.md",
     "demo": "./node_modules/webpack/bin/webpack.js --env=dist-docs",
     "docs": "npm run jsdoc; npm run demo",

--- a/src/renderers/dom/ui/elements/Controls/ColorControl.js
+++ b/src/renderers/dom/ui/elements/Controls/ColorControl.js
@@ -22,6 +22,7 @@ class ColorControl extends React.Component {
   }
 
   render () {
+    if (!this.props.layer.editable) return null;
     if (!this.props.layer.editable[this.props.name]) return null;
 
     if (typeof this.props.layer.editable[this.props.name] === 'object' && this.props.layer.editable[this.props.name].options) {

--- a/src/renderers/dom/ui/elements/Controls/SizeControl.js
+++ b/src/renderers/dom/ui/elements/Controls/SizeControl.js
@@ -61,8 +61,8 @@ SizeControl.propTypes = {
   layer: React.PropTypes.object.isRequired,
   min: React.PropTypes.number,
   max: React.PropTypes.number,
-  step: React.PropTypes.number,
-  type: React.PropTypes.string
+  step: React.PropTypes.number
+  // type: React.PropTypes.string
 }
 
 // Export

--- a/test/ui/elements/Controls/ColorControl.spec.js
+++ b/test/ui/elements/Controls/ColorControl.spec.js
@@ -2,33 +2,238 @@
 const chai = require('chai');
 const sinon = require('sinon');
 const jsdom = require('mocha-jsdom');
+const { ChromePicker, CirclePicker } = require('react-color');
 
 // Import React libs
 const React = require('react');
 const ReactDOM = require('react-dom');
 const ReactDOMServer = require('react-dom/server');
+const TestUtils = require('react-dom/test-utils');
 
 // Tell chai that we'll be using the "should" style assertions.
-chai.should();
-
-// function requireUncached(module){
-//     delete require.cache[require.resolve(module)]
-//     return require(module)
-// }
+const should = chai.should();
 
 // Import ColorControl
 const ColorControl = require('../../../../src/renderers/dom/ui/elements/Controls/ColorControl');
 
+
 describe('ui/elements/ColorControl', () => {
-    xit ('should fail test', () => {
-        (() => {
-            'Failed test';
-        }).should.throw(Error);
+
+    // Enable JSDom
+    jsdom();
+
+    describe('null case', () => {
+        it('should be null if layer have no "editable" key', () => {
+            const component = TestUtils.renderIntoDocument(
+                <ColorControl name='test_name'
+                layer={{}}
+                onNewValue={() => null} />
+            );
+            const rendered = ReactDOM.findDOMNode(component);
+            should.not.exist(rendered);
+        });
+
+        it('should be null if layer.editable does not have `name` key', () => {
+            const component = TestUtils.renderIntoDocument(
+                <ColorControl name='test_name'
+                layer={{editable: {another_name: true}}}
+                onNewValue={() => null} />
+            );
+            const rendered = ReactDOM.findDOMNode(component);
+            should.not.exist(rendered);
+        });
+
+        it('should be null if layer.editable[`name`] is false', () => {
+            const component = TestUtils.renderIntoDocument(
+                <ColorControl name='test_name'
+                layer={{editable: {test_name: false}}}
+                onNewValue={() => null} />
+            );
+            const rendered = ReactDOM.findDOMNode(component);
+            should.not.exist(rendered);
+        });
+
+        it('should be null if layer.editable[`name`] is string except for "picker"', () => {
+            const componentWithEmptyString = TestUtils.renderIntoDocument(
+                <ColorControl name='test_name'
+                layer={{editable: {test_name: ''}}}
+                onNewValue={() => null} />
+            );
+            const componentWithInvalidString = TestUtils.renderIntoDocument(
+                <ColorControl name='test_name'
+                layer={{editable: {test_name: 'test_string'}}}
+                onNewValue={() => null} />
+            );
+            const renderedWithEmptyString = ReactDOM.findDOMNode(componentWithEmptyString);
+            const renderedWithInvalidString = ReactDOM.findDOMNode(componentWithInvalidString);
+            should.not.exist(renderedWithEmptyString);
+            should.not.exist(renderedWithEmptyString);
+        });
+
+        it('should be null if layer.editable[`name`] is object without "options"', () => {
+            const layer = {editable: {test_name: {"without": "options"}}};
+            const component = TestUtils.renderIntoDocument(
+                <ColorControl name='test_name'
+                layer={layer}
+                onNewValue={() => null} />
+            );
+            const rendered  = ReactDOM.findDOMNode(component);
+            should.not.exist(rendered);
+        });
     });
 
-    it ('should pass test', () => {
-        (() => {
-            'passed test';
+
+    describe('CirclePicker case', () => {
+
+        let component,
+            rendered,
+            callback,
+            picker;
+
+        before('render', () => {
+            callback = sinon.spy();
+            const layer = {
+                editable: {
+                    test_name: {
+                        options: ['black', '#D9E3F0',  '#FFF']
+                    }
+                }
+            };
+            component = TestUtils.renderIntoDocument(
+                <ColorControl name='test_name'
+                layer={layer}
+                onNewValue={callback} />
+            );
+            rendered  = ReactDOM.findDOMNode(component);
+        });
+
+        it('should render CirclePicker if layer.editable[`name`] is object with "options"', () => {
+            should.exist(rendered);
+            picker = TestUtils.findRenderedComponentWithType(
+                component,
+                CirclePicker
+            );
+
+            // No ChromePicker
+            (() => {
+                TestUtils.findRenderedComponentWithType(
+                    component,
+                    ChromePicker
+                );
+            }).should.throw(Error);
+
+            // No input-picker
+            rendered.lastChild.tagName.should.not.be.equal("INPUT");
+        });
+
+        it('should call onNewValue if onChange triggered ', () => {
+            const testColor = "#222222";
+            // forced trigger CirclePicker's onChange;
+            picker.handleChange(testColor, null);
+
+            callback.withArgs("test_name", testColor).calledOnce.should.be.ok;
+        });
+    });
+
+    describe('ChromePicker case', () => {
+
+        let component,
+            rendered,
+            callback,
+            picker;
+
+        before('render', () => {
+            callback = sinon.spy();
+            const layer = {
+                editable: {
+                    test_name: 'picker'
+                }
+            };
+            component = TestUtils.renderIntoDocument(
+                <ColorControl name='test_name'
+                layer={layer}
+                onNewValue={callback} />
+            );
+            rendered  = ReactDOM.findDOMNode(component);
+        });
+
+        it('should render ChromePicker if layer.editable[`name`] is "picker"', () => {
+            should.exist(rendered);
+            picker = TestUtils.findRenderedComponentWithType(
+                component,
+                ChromePicker
+            );
+
+            // No CirclePicker
+            (() => {
+                TestUtils.findRenderedComponentWithType(
+                    component,
+                    CirclePicker
+                );
+            }).should.throw(Error);
+
+            // No input picker
+            rendered.lastChild.tagName.should.not.be.equal("INPUT");
+        });
+
+        it('should call onNewValue if onChange of ChromePicker triggered ', () => {
+            const testColor = {hex: "#222222"};
+            // forced trigger ChromePicker's onChange;
+            picker.handleChange(testColor.hex, null);
+
+            callback.withArgs("test_name", testColor.hex).calledOnce.should.be.ok;
+        });
+    });
+
+    describe('input-picker case', () => {
+        let component,
+            rendered,
+            callback,
+            picker;
+
+        before('render', () => {
+            callback = sinon.spy();
+            const layer = {
+                editable: {
+                    test_name: true
+                }
+            };
+            component = TestUtils.renderIntoDocument(
+                <ColorControl name='test_name'
+                layer={layer}
+                onNewValue={callback} />
+            );
+            rendered  = ReactDOM.findDOMNode(component);
+        });
+
+        it('should render input-tag color picker if layer.editable[`name`] is true', () => {
+            should.exist(rendered);
+            picker = TestUtils.findRenderedDOMComponentWithTag(
+                component,
+                'input'
+            );
+
+            // No CirclePicker
+            (() => {
+                TestUtils.findRenderedComponentWithType(
+                    component,
+                    CirclePicker
+                );
+            }).should.throw(Error);
+
+            // No ChomePicker
+            (() => {
+                TestUtils.findRenderedComponentWithType(
+                    component,
+                    ChromePicker
+                );
+            }).should.throw(Error);
+        });
+        it("should call onNewValue with args if onChange", () => {
+            const testColorHex =  "#222222";
+            picker.value = testColorHex;
+            TestUtils.Simulate.change(picker);
+            callback.withArgs("test_name", testColorHex).calledOnce.should.be.ok;
         });
     });
 });

--- a/test/ui/elements/Controls/ColorControl.spec.js
+++ b/test/ui/elements/Controls/ColorControl.spec.js
@@ -22,218 +22,220 @@ describe('ui/elements/ColorControl', () => {
     // Enable JSDom
     jsdom();
 
-    describe('null case', () => {
-        it('should be null if layer have no "editable" key', () => {
-            const component = TestUtils.renderIntoDocument(
-                <ColorControl name='test_name'
-                layer={{}}
-                onNewValue={() => null} />
-            );
-            const rendered = ReactDOM.findDOMNode(component);
-            should.not.exist(rendered);
+    describe('#render()', () => {
+        describe('null case', () => {
+            it('should be null if layer have no "editable" key', () => {
+                const component = TestUtils.renderIntoDocument(
+                    <ColorControl name='test_name'
+                    layer={{}}
+                    onNewValue={() => null} />
+                );
+                const rendered = ReactDOM.findDOMNode(component);
+                should.not.exist(rendered);
+            });
+
+            it('should be null if layer.editable does not have `name` key', () => {
+                const component = TestUtils.renderIntoDocument(
+                    <ColorControl name='test_name'
+                    layer={{editable: {another_name: true}}}
+                    onNewValue={() => null} />
+                );
+                const rendered = ReactDOM.findDOMNode(component);
+                should.not.exist(rendered);
+            });
+
+            it('should be null if layer.editable[`name`] is false', () => {
+                const component = TestUtils.renderIntoDocument(
+                    <ColorControl name='test_name'
+                    layer={{editable: {test_name: false}}}
+                    onNewValue={() => null} />
+                );
+                const rendered = ReactDOM.findDOMNode(component);
+                should.not.exist(rendered);
+            });
+
+            it('should be null if layer.editable[`name`] is string except for "picker"', () => {
+                const componentWithEmptyString = TestUtils.renderIntoDocument(
+                    <ColorControl name='test_name'
+                    layer={{editable: {test_name: ''}}}
+                    onNewValue={() => null} />
+                );
+                const componentWithInvalidString = TestUtils.renderIntoDocument(
+                    <ColorControl name='test_name'
+                    layer={{editable: {test_name: 'test_string'}}}
+                    onNewValue={() => null} />
+                );
+                const renderedWithEmptyString = ReactDOM.findDOMNode(componentWithEmptyString);
+                const renderedWithInvalidString = ReactDOM.findDOMNode(componentWithInvalidString);
+                should.not.exist(renderedWithEmptyString);
+                should.not.exist(renderedWithEmptyString);
+            });
+
+            it('should be null if layer.editable[`name`] is object without "options"', () => {
+                const layer = {editable: {test_name: {"without": "options"}}};
+                const component = TestUtils.renderIntoDocument(
+                    <ColorControl name='test_name'
+                    layer={layer}
+                    onNewValue={() => null} />
+                );
+                const rendered  = ReactDOM.findDOMNode(component);
+                should.not.exist(rendered);
+            });
         });
 
-        it('should be null if layer.editable does not have `name` key', () => {
-            const component = TestUtils.renderIntoDocument(
-                <ColorControl name='test_name'
-                layer={{editable: {another_name: true}}}
-                onNewValue={() => null} />
-            );
-            const rendered = ReactDOM.findDOMNode(component);
-            should.not.exist(rendered);
-        });
 
-        it('should be null if layer.editable[`name`] is false', () => {
-            const component = TestUtils.renderIntoDocument(
-                <ColorControl name='test_name'
-                layer={{editable: {test_name: false}}}
-                onNewValue={() => null} />
-            );
-            const rendered = ReactDOM.findDOMNode(component);
-            should.not.exist(rendered);
-        });
+        describe('CirclePicker case', () => {
 
-        it('should be null if layer.editable[`name`] is string except for "picker"', () => {
-            const componentWithEmptyString = TestUtils.renderIntoDocument(
-                <ColorControl name='test_name'
-                layer={{editable: {test_name: ''}}}
-                onNewValue={() => null} />
-            );
-            const componentWithInvalidString = TestUtils.renderIntoDocument(
-                <ColorControl name='test_name'
-                layer={{editable: {test_name: 'test_string'}}}
-                onNewValue={() => null} />
-            );
-            const renderedWithEmptyString = ReactDOM.findDOMNode(componentWithEmptyString);
-            const renderedWithInvalidString = ReactDOM.findDOMNode(componentWithInvalidString);
-            should.not.exist(renderedWithEmptyString);
-            should.not.exist(renderedWithEmptyString);
-        });
+            let component,
+                rendered,
+                callback,
+                picker;
 
-        it('should be null if layer.editable[`name`] is object without "options"', () => {
-            const layer = {editable: {test_name: {"without": "options"}}};
-            const component = TestUtils.renderIntoDocument(
-                <ColorControl name='test_name'
-                layer={layer}
-                onNewValue={() => null} />
-            );
-            const rendered  = ReactDOM.findDOMNode(component);
-            should.not.exist(rendered);
-        });
-    });
-
-
-    describe('CirclePicker case', () => {
-
-        let component,
-            rendered,
-            callback,
-            picker;
-
-        before('render', () => {
-            callback = sinon.spy();
-            const layer = {
-                editable: {
-                    test_name: {
-                        options: ['black', '#D9E3F0',  '#FFF']
+            before('render', () => {
+                callback = sinon.spy();
+                const layer = {
+                    editable: {
+                        test_name: {
+                            options: ['black', '#D9E3F0',  '#FFF']
+                        }
                     }
-                }
-            };
-            component = TestUtils.renderIntoDocument(
-                <ColorControl name='test_name'
-                layer={layer}
-                onNewValue={callback} />
-            );
-            rendered  = ReactDOM.findDOMNode(component);
-        });
-
-        it('should render CirclePicker if layer.editable[`name`] is object with "options"', () => {
-            should.exist(rendered);
-            picker = TestUtils.findRenderedComponentWithType(
-                component,
-                CirclePicker
-            );
-
-            // No ChromePicker
-            (() => {
-                TestUtils.findRenderedComponentWithType(
-                    component,
-                    ChromePicker
+                };
+                component = TestUtils.renderIntoDocument(
+                    <ColorControl name='test_name'
+                    layer={layer}
+                    onNewValue={callback} />
                 );
-            }).should.throw(Error);
+                rendered  = ReactDOM.findDOMNode(component);
+            });
 
-            // No input-picker
-            rendered.lastChild.tagName.should.not.be.equal("INPUT");
-        });
-
-        it('should call onNewValue if onChange triggered ', () => {
-            const testColor = "#222222";
-            // forced trigger CirclePicker's onChange;
-            picker.handleChange(testColor, null);
-
-            callback.withArgs("test_name", testColor).calledOnce.should.be.ok;
-        });
-    });
-
-    describe('ChromePicker case', () => {
-
-        let component,
-            rendered,
-            callback,
-            picker;
-
-        before('render', () => {
-            callback = sinon.spy();
-            const layer = {
-                editable: {
-                    test_name: 'picker'
-                }
-            };
-            component = TestUtils.renderIntoDocument(
-                <ColorControl name='test_name'
-                layer={layer}
-                onNewValue={callback} />
-            );
-            rendered  = ReactDOM.findDOMNode(component);
-        });
-
-        it('should render ChromePicker if layer.editable[`name`] is "picker"', () => {
-            should.exist(rendered);
-            picker = TestUtils.findRenderedComponentWithType(
-                component,
-                ChromePicker
-            );
-
-            // No CirclePicker
-            (() => {
-                TestUtils.findRenderedComponentWithType(
+            it('should render CirclePicker if layer.editable[`name`] is object with "options"', () => {
+                should.exist(rendered);
+                picker = TestUtils.findRenderedComponentWithType(
                     component,
                     CirclePicker
                 );
-            }).should.throw(Error);
 
-            // No input picker
-            rendered.lastChild.tagName.should.not.be.equal("INPUT");
+                // No ChromePicker
+                (() => {
+                    TestUtils.findRenderedComponentWithType(
+                        component,
+                        ChromePicker
+                    );
+                }).should.throw(Error);
+
+                // No input-picker
+                rendered.lastChild.tagName.should.not.be.equal("INPUT");
+            });
+
+            it('should call onNewValue if onChange triggered ', () => {
+                const testColor = "#222222";
+                // forced trigger CirclePicker's onChange;
+                picker.handleChange(testColor, null);
+
+                callback.withArgs("test_name", testColor).calledOnce.should.be.ok;
+            });
         });
 
-        it('should call onNewValue if onChange of ChromePicker triggered ', () => {
-            const testColor = {hex: "#222222"};
-            // forced trigger ChromePicker's onChange;
-            picker.handleChange(testColor.hex, null);
+        describe('ChromePicker case', () => {
 
-            callback.withArgs("test_name", testColor.hex).calledOnce.should.be.ok;
-        });
-    });
+            let component,
+                rendered,
+                callback,
+                picker;
 
-    describe('input-picker case', () => {
-        let component,
-            rendered,
-            callback,
-            picker;
-
-        before('render', () => {
-            callback = sinon.spy();
-            const layer = {
-                editable: {
-                    test_name: true
-                }
-            };
-            component = TestUtils.renderIntoDocument(
-                <ColorControl name='test_name'
-                layer={layer}
-                onNewValue={callback} />
-            );
-            rendered  = ReactDOM.findDOMNode(component);
-        });
-
-        it('should render input-tag color picker if layer.editable[`name`] is true', () => {
-            should.exist(rendered);
-            picker = TestUtils.findRenderedDOMComponentWithTag(
-                component,
-                'input'
-            );
-
-            // No CirclePicker
-            (() => {
-                TestUtils.findRenderedComponentWithType(
-                    component,
-                    CirclePicker
+            before('render', () => {
+                callback = sinon.spy();
+                const layer = {
+                    editable: {
+                        test_name: 'picker'
+                    }
+                };
+                component = TestUtils.renderIntoDocument(
+                    <ColorControl name='test_name'
+                    layer={layer}
+                    onNewValue={callback} />
                 );
-            }).should.throw(Error);
+                rendered  = ReactDOM.findDOMNode(component);
+            });
 
-            // No ChomePicker
-            (() => {
-                TestUtils.findRenderedComponentWithType(
+            it('should render ChromePicker if layer.editable[`name`] is "picker"', () => {
+                should.exist(rendered);
+                picker = TestUtils.findRenderedComponentWithType(
                     component,
                     ChromePicker
                 );
-            }).should.throw(Error);
+
+                // No CirclePicker
+                (() => {
+                    TestUtils.findRenderedComponentWithType(
+                        component,
+                        CirclePicker
+                    );
+                }).should.throw(Error);
+
+                // No input picker
+                rendered.lastChild.tagName.should.not.be.equal("INPUT");
+            });
+
+            it('should call onNewValue if onChange of ChromePicker triggered ', () => {
+                const testColor = {hex: "#222222"};
+                // forced trigger ChromePicker's onChange;
+                picker.handleChange(testColor.hex, null);
+
+                callback.withArgs("test_name", testColor.hex).calledOnce.should.be.ok;
+            });
         });
-        it("should call onNewValue with args if onChange", () => {
-            const testColorHex =  "#222222";
-            picker.value = testColorHex;
-            TestUtils.Simulate.change(picker);
-            callback.withArgs("test_name", testColorHex).calledOnce.should.be.ok;
+
+        describe('input-picker case', () => {
+            let component,
+                rendered,
+                callback,
+                picker;
+
+            before('render', () => {
+                callback = sinon.spy();
+                const layer = {
+                    editable: {
+                        test_name: true
+                    }
+                };
+                component = TestUtils.renderIntoDocument(
+                    <ColorControl name='test_name'
+                    layer={layer}
+                    onNewValue={callback} />
+                );
+                rendered  = ReactDOM.findDOMNode(component);
+            });
+
+            it('should render input-tag color picker if layer.editable[`name`] is true', () => {
+                should.exist(rendered);
+                picker = TestUtils.findRenderedDOMComponentWithTag(
+                    component,
+                    'input'
+                );
+
+                // No CirclePicker
+                (() => {
+                    TestUtils.findRenderedComponentWithType(
+                        component,
+                        CirclePicker
+                    );
+                }).should.throw(Error);
+
+                // No ChomePicker
+                (() => {
+                    TestUtils.findRenderedComponentWithType(
+                        component,
+                        ChromePicker
+                    );
+                }).should.throw(Error);
+            });
+            it("should call onNewValue with args if onChange", () => {
+                const testColorHex =  "#222222";
+                picker.value = testColorHex;
+                TestUtils.Simulate.change(picker);
+                callback.withArgs("test_name", testColorHex).calledOnce.should.be.ok;
+            });
         });
     });
 });

--- a/test/ui/elements/Controls/ColorControl.spec.js
+++ b/test/ui/elements/Controls/ColorControl.spec.js
@@ -1,0 +1,34 @@
+// Import assertion + helper libs
+const chai = require('chai');
+const sinon = require('sinon');
+const jsdom = require('mocha-jsdom');
+
+// Import React libs
+const React = require('react');
+const ReactDOM = require('react-dom');
+const ReactDOMServer = require('react-dom/server');
+
+// Tell chai that we'll be using the "should" style assertions.
+chai.should();
+
+// function requireUncached(module){
+//     delete require.cache[require.resolve(module)]
+//     return require(module)
+// }
+
+// Import ColorControl
+const ColorControl = require('../../../../src/renderers/dom/ui/elements/Controls/ColorControl');
+
+describe('ui/elements/ColorControl', () => {
+    xit ('should fail test', () => {
+        (() => {
+            'Failed test';
+        }).should.throw(Error);
+    });
+
+    it ('should pass test', () => {
+        (() => {
+            'passed test';
+        });
+    });
+});


### PR DESCRIPTION
related: https://github.com/times/cardkit/issues/61

Basically, this PR just added tests to `ColorControl.js` based on its original implementation,
I mean, it never adds any feature or functionality and is tiny improvement about coverage.
There is no real reason for starting with `ColorControl`.

Anyway...
Writing tests of `ColorControl` gave me 3 ideas.

1. it may be better for `ColorControl` to have a validator for `layer` prop.
    -  `ColorControl` virtually requires `layer.editable` property but it is implicative.
2. Considered about the previous idea, it may be better for `layer.editable` to have consistency in terms of type.
    - For now, `layer.editable[name]` accepts object, string and boolean and it defines DOM content of `ColorControl`. I suspect this is complicated.
    - Just an idea
       - `editable: {picker: 'circle', options: [...]}` => `CirclePicker`
       - `editable: {picker: 'chrome'}` =>  `ChromePicker`
       - `editable: {picker: 'input'}` => `input tag`
3. `ColorControl#handleChange` should validate an argument.
    - Because it may not be a color-associated string.
 
If you are favor of even one of the ideas, I am willing to implement it (them) in next PR.
Thanks for reading.